### PR TITLE
Update azure-webapps-node.yml

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -50,10 +50,9 @@ jobs:
 
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v3
-      with:
-        name: node-app
-        path: .
-
+    name: node-app
+    path: ./dist # Update to the actual output directory if applicable
+    
   deploy:
     permissions:
       contents: none

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,10 +1,6 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
 name: Node.js CI
-
-permissions:
-  contents: read
 
 on:
   push:
@@ -14,13 +10,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v4
@@ -29,6 +22,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - run: npm install && npm ci --dry-run
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
+    


### PR DESCRIPTION
## Summary by Sourcery

Update the Azure Web Apps GitHub Actions workflow to upload the built output directory instead of the repository root

CI:
- Change the upload-artifact step to target './dist' rather than '.'
- Remove the redundant 'with' block and inline the artifact name and path